### PR TITLE
Main - switch values based on intersection

### DIFF
--- a/src/components/About/About.jsx
+++ b/src/components/About/About.jsx
@@ -1,13 +1,22 @@
-import React from 'react'
+import React, { useRef, useContext, useEffect } from 'react'
 import aboutUsImg from '../../assets/AboutUs-unsplash.jpg'
 import Lottie from "lottie-react";
 import measuringTape from '../../assets/measuringTape.json'
 import placeholder from '../../assets/placeholder.jpg'
+import { Context } from '../../context/SideBarContext';
 import './About.css'
+import useObserver from '../../hooks/useObserver';
 
 const AboutUs = ()=>{
-    return(
-        <section id="AboutUs" className='--about-section-container'>
+    const aboutUsRef = useRef(null)
+    const { setSideBarValue } = useContext(Context)
+    const isIntersecting = useObserver(aboutUsRef)
+
+    useEffect(() => {
+        isIntersecting ? setSideBarValue("About Us") : null
+    },[isIntersecting])
+        return(
+        <section ref={aboutUsRef} id="AboutUs" className='--about-section-container'>
             <img id='about-img' className='--about-img' src={aboutUsImg} alt="" />
             <div className='--about-text-container'>
                 <h2 className='--about-home-tag'>Tired of your <span>Home</span></h2>

--- a/src/components/Jumbo/Jumbo.jsx
+++ b/src/components/Jumbo/Jumbo.jsx
@@ -1,11 +1,20 @@
-import React from 'react'
+import React, { useRef, useEffect, useContext } from 'react'
 import Lottie from "lottie-react";
 import Home3D from '../../assets/home3d.json'
+import useObserver from '../../hooks/useObserver';
+import { Context } from "../../context/SideBarContext"
 import './Jumbo.css'
 
 const Jumbo = ()=>{
+    const homeRef = useRef(null)
+    const isIntersecting = useObserver(homeRef)
+    const { setSideBarValue } = useContext(Context)
+
+    useEffect(() => {
+        isIntersecting ? setSideBarValue("Home") : null
+    },[isIntersecting])
     return(
-        <section id="Home" className='--layout-jumbo-section'>
+        <section ref={homeRef} id="Home" className='--layout-jumbo-section'>
             <Lottie id='jumbo-anim' className='--layout-jumbo-anim'  animationData={Home3D} loop={true} />
             <h2 className='--layout-jumbo-title'>Quality Renovations for LARGE & small Homes</h2>
             <p className='--layout-jumbo-text'>Revamp your living space with our exceptional home renovation services. We deliver functional and stylish results that increase your property value. Let's bring your vision to life!</p>

--- a/src/components/Testimonial/Testimonial.jsx
+++ b/src/components/Testimonial/Testimonial.jsx
@@ -1,10 +1,19 @@
-import React from 'react'
+import React, { useRef, useEffect, useContext } from 'react'
 import Carousel from 'react-bootstrap/Carousel';
+import { Context } from "../../context/SideBarContext"
+import useObserver from '../../hooks/useObserver';
 import './Testimonial.css'
 
 const Testimonial = ()=>{
+    const feedbackRef = useRef(null)
+    const isIntersecting = useObserver(feedbackRef)
+    const { setSideBarValue } = useContext(Context)
+
+    useEffect(() => {
+        isIntersecting ? setSideBarValue("Testimonials"): null
+    },[isIntersecting])
     return(
-        <section id='Feedback' className='--testimonial-section-container '>
+        <section ref={feedbackRef} id='Feedback' className='--testimonial-section-container '>
             <h2 className='--testimonial-tagline black bold center'>Testimonials speak volumes. They fuel our passion for delivering exceptional home renovations.</h2>
             <div className='--testimonial-carousel-container'>
             <Carousel>

--- a/src/context/SideBarContext.jsx
+++ b/src/context/SideBarContext.jsx
@@ -1,0 +1,15 @@
+import React, { createContext, useState } from "react"
+
+const Context = createContext()
+export default function SideBarContext ({ children }) {
+    const [sideBarValue, setSideBarValue] = useState("Home")
+    return (
+        <>
+        <Context.Provider value={{sideBarValue, setSideBarValue}}>
+            {children}
+        </Context.Provider>
+        </>
+    )
+}
+
+export { Context }

--- a/src/hooks/useObserver.jsx
+++ b/src/hooks/useObserver.jsx
@@ -1,0 +1,29 @@
+import React, { useState, useEffect } from "react"
+
+export default function useObserver(node){
+    const [isIntersecting, setIsIntersecting] = useState(false)
+
+    useEffect(() => {
+        let options =  {
+            rootMargin: "10px",
+            threshold: 0.5
+        }
+        const observer = new IntersectionObserver(handleObserver, options)
+
+        if(node.current){
+            observer.observe(node.current)
+        }
+
+        return () => {
+            observer.disconnect()
+        }
+
+    },[isIntersecting])
+
+    function handleObserver(entries) {
+        const [ entry ] = entries
+        setIsIntersecting(entry.isIntersecting)
+    }
+
+    return isIntersecting
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,6 +7,7 @@ import Home from './pages/Home/Home'
 import Portfolio from './pages/Portfolio/Portfolio'
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.css'
+import SideBarContext from './context/SideBarContext'
 
 const router = createBrowserRouter(createRoutesFromElements(
   <Route path='/' element={<Layout />} loader={layoutLoader} errorElement={<Error />}>
@@ -19,6 +20,8 @@ const router = createBrowserRouter(createRoutesFromElements(
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <RouterProvider router={router}/>
+    <SideBarContext>
+      <RouterProvider router={router}/>
+    </SideBarContext>
   </React.StrictMode>,
 )

--- a/src/pages/Layout/Layout.jsx
+++ b/src/pages/Layout/Layout.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useContext } from 'react'
 import fbIcon from '../../assets/icons/facebook.svg'
 import instaIcon from '../../assets/icons/instagram.svg'
 import tiktokIcon from '../../assets/icons/tiktok.svg'
@@ -8,6 +8,7 @@ import MobileHeader from '../../components/MobileHeader/MobileHeader'
 import DesktopHeader from '../../components/DesktopHeader/DesktopHeader'
 import { useCurrentWidth } from '../../hooks/findWidth'
 import woodGrain from '../../assets/woodGrain-unsplash.jpg'
+import { Context } from "../../context/SideBarContext"
 import './Layout.css'
 
 
@@ -18,28 +19,9 @@ export const loader = ()=>{
 export const Layout = ()=> {
   const width = useCurrentWidth()
   const currentSection = useRef()
+  const {sideBarValue} = useContext(Context)
 
-  useEffect(()=>{
-    document.addEventListener('DOMContentLoaded', addObserver)
-
-    return ()=>{
-      document.removeEventListener('DOMContentLoaded', addObserver)
-    }
-  },[])
-
-  function addObserver(){
-    let options = {
-      root: document.querySelector("#root"),
-      rootMargin: '0px',
-      threshold:.01
-    }
   
-    let observer = new IntersectionObserver(handleObserver, options)
-    console.log(observer)
-    let target = document.querySelector("#AboutUs");
-  
-    observer.observe(target)
-  }
   
   const asideContainerStyles = {
       backgroundImage:`URL(${woodGrain})`,
@@ -47,17 +29,14 @@ export const Layout = ()=> {
       backgroundRepeat:'no-repeat'
   }
 
-  function handleObserver(){
-    console.log(`we have reached an observer`)
-  }
   
   return(
     <>    
       {width < 750 ? (<MobileHeader/>): (<DesktopHeader/>)}
-      <div id='content-container'>
+      <div id='content-container' ref={currentSection}>
         <div className='--layout-aside-container' style={asideContainerStyles}>
           <div className='--layout-aside-content-container flex flex-column'>
-            <h2 className='--layout-current-nav white center' ref={currentSection}>About Us</h2>   
+            <h2 className='--layout-current-nav white center' >{sideBarValue}</h2>   
             <div className='--layout-aside-social-container'>
               <ul className='--layout-aside-social-list flex flex-column flex-center flex-align-center'>
                 <Link><li><img className='social-icon fb' src={fbIcon} alt="facebook icon" /></li></Link>
@@ -73,7 +52,6 @@ export const Layout = ()=> {
           
         </div>   
       </div>
-      
     </>
   )
 }


### PR DESCRIPTION
I created a `useObserver` hook that takes in the ref value and checks to make sure that `node.current` is not null. I used a context provider that wrapped the app passing state down to other components that otherwise would be able to accept it without restructuring your app. 
I removed the observer from the `Layout.jsx`. You were close, but it was a little off. Also, trying to target the `root` element seemed to be effecting it as well. 
The components are using their own `refs` and for their respective section. When the observer intersects the `entry`, it sets a state to check that the section is intersecting and updates the context provider with the value for that section, effectively changing the name of the sidebar for the section it is on.
I don't think I left anything out, but if any questions, I will do my best to answer. This is the first time ever hearing about or using the `IntersectionObserver` for me.